### PR TITLE
Decouple restli request uri creation so it's pluggable by consumers

### DIFF
--- a/play-restli/src/main/java/com/linkedin/playrestli/DefaultRestliUriResolver.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/DefaultRestliUriResolver.java
@@ -1,0 +1,67 @@
+package com.linkedin.playrestli;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
+import play.Logger;
+import play.api.http.HttpConfiguration;
+
+
+/**
+ * A default implementation to prepare the restli request uri
+ */
+@Singleton
+public class DefaultRestliUriResolver implements RestliUriResolver {
+  private static final Logger.ALogger LOGGER = Logger.of(DefaultRestliUriResolver.class);
+  private final String _playContext;
+
+  @Inject
+  public DefaultRestliUriResolver(HttpConfiguration httpConfiguration) {
+    _playContext = StringUtils.removeEnd(httpConfiguration.context(), "/");
+  }
+
+  @Override
+  public Optional<URI> getRestliUri(String uri, String path) throws URISyntaxException {
+    if (!uri.contains(path)) {
+      LOGGER.error(String.format("URI (%s) and path (%s) mismatch", uri, path));
+      return Optional.empty();
+    }
+    String cleanUri = stripSchemeAuthority(uri, path);
+    if (_playContext.isEmpty()) {
+      return Optional.of(new URI(cleanUri));
+    }
+    if (path.startsWith(_playContext) && (path.length() == _playContext.length()
+        || path.charAt(_playContext.length()) == '/')) {
+      return Optional.of(new URI(cleanUri.substring(_playContext.length())));
+    } else {
+      LOGGER.error("Play context is not leading the path part of the URI: " + uri);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Strips scheme and authority parts from URI.
+   */
+  private String stripSchemeAuthority(String uri, String path) {
+    int startIndex;
+    if (!path.isEmpty()) {
+      // If path exists, then starts with path
+      startIndex = uri.indexOf(path);
+    } else{
+      // If query exists, then starts with query
+      startIndex = uri.indexOf('?');
+      if (startIndex == -1) {
+        // If fragment exists, then starts with fragment
+        startIndex = uri.indexOf('#');
+        if (startIndex == -1) {
+          // If none exists, then return empty
+          return "";
+        }
+      }
+    }
+    return uri.substring(startIndex);
+  }
+}

--- a/play-restli/src/main/java/com/linkedin/playrestli/RestliServerComponent.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/RestliServerComponent.java
@@ -23,9 +23,9 @@ import play.mvc.Http;
 public final class RestliServerComponent extends BaseRestliServerComponent<RestRequest> implements RestliServerApi {
 
   @Inject
-  public RestliServerComponent(HttpConfiguration httpConfiguration, CookiesConfiguration cookiesConfiguration,
-      HttpDispatcher httpDispatcher) {
-    super(httpConfiguration, cookiesConfiguration, httpDispatcher);
+  public RestliServerComponent(CookiesConfiguration cookiesConfiguration,
+      HttpDispatcher httpDispatcher, RestliUriResolver restliUriResolver) {
+    super(cookiesConfiguration, httpDispatcher, restliUriResolver);
   }
 
   /**

--- a/play-restli/src/main/java/com/linkedin/playrestli/RestliServerModule.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/RestliServerModule.java
@@ -68,7 +68,8 @@ public class RestliServerModule extends Module {
         dynBinding(ResourceFactory.class, "resourceFactory"),
         dynProvider(Engine.class, EngineProvider.class, "engineProvider"),
         dynProvider(RestLiConfig.class, RestliConfigProvider.class, "configProvider"),
-        dynProvider(HttpDispatcher.class, HttpDispatcherProvider.class, "httpDispatcherProvider")
+        dynProvider(HttpDispatcher.class, HttpDispatcherProvider.class, "httpDispatcherProvider"),
+        bindClass(RestliUriResolver.class).to(DefaultRestliUriResolver.class)
     );
   }
 }

--- a/play-restli/src/main/java/com/linkedin/playrestli/RestliServerStreamComponent.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/RestliServerStreamComponent.java
@@ -27,9 +27,9 @@ import play.mvc.Http;
 public final class RestliServerStreamComponent extends BaseRestliServerComponent<StreamRequest>
     implements RestliServerStreamApi {
   @Inject
-  public RestliServerStreamComponent(HttpConfiguration httpConfiguration, CookiesConfiguration cookiesConfiguration,
-      HttpDispatcher httpDispatcher) {
-    super(httpConfiguration, cookiesConfiguration, httpDispatcher);
+  public RestliServerStreamComponent(CookiesConfiguration cookiesConfiguration,
+      HttpDispatcher httpDispatcher, RestliUriResolver restliUriResolver) {
+    super(cookiesConfiguration, httpDispatcher, restliUriResolver);
   }
 
   /**

--- a/play-restli/src/main/java/com/linkedin/playrestli/RestliUriResolver.java
+++ b/play-restli/src/main/java/com/linkedin/playrestli/RestliUriResolver.java
@@ -1,0 +1,13 @@
+package com.linkedin.playrestli;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+
+/**
+ * Necessary process on Play's  request uri to form the uri to be used with restli request
+ */
+public interface RestliUriResolver {
+  Optional<URI> getRestliUri(String uri, String path) throws URISyntaxException;
+}

--- a/play-restli/src/test/java/com/linkedin/playrestli/TestRestliServerComponent.java
+++ b/play-restli/src/test/java/com/linkedin/playrestli/TestRestliServerComponent.java
@@ -47,7 +47,8 @@ public class TestRestliServerComponent {
     expect(config.context()).andReturn(CONTEXT);
     replay(config);
     _httpDispatcher = createMock(HttpDispatcher.class);
-    restliServer = new RestliServerComponent(config, CookiesConfiguration.apply(true), _httpDispatcher);
+    RestliUriResolver restliUriResolver = new DefaultRestliUriResolver(config);
+    restliServer = new RestliServerComponent(CookiesConfiguration.apply(true), _httpDispatcher, restliUriResolver);
   }
 
   @Test

--- a/play-restli/src/test/java/com/linkedin/playrestli/TestRestliStreamServerComponent.java
+++ b/play-restli/src/test/java/com/linkedin/playrestli/TestRestliStreamServerComponent.java
@@ -58,7 +58,8 @@ public class TestRestliStreamServerComponent {
     expect(config.context()).andReturn(CONTEXT);
     replay(config);
     _httpDispatcher = createMock(HttpDispatcher.class);
-    restliServer = new RestliServerStreamComponent(config, CookiesConfiguration.apply(true), _httpDispatcher);
+    RestliUriResolver restliUriResolver = new DefaultRestliUriResolver(config);
+    restliServer = new RestliServerStreamComponent(CookiesConfiguration.apply(true), _httpDispatcher, restliUriResolver);
   }
 
   @Test


### PR DESCRIPTION
Restli request uri creation is decoupled so that it can be replace if consumers want. 